### PR TITLE
Add recipe for seen-mode

### DIFF
--- a/recipes/seen-mode
+++ b/recipes/seen-mode
@@ -1,0 +1,3 @@
+(seen-mode
+ :fetcher git
+ :url "https://git.sr.ht/~shiorid/seen.el")


### PR DESCRIPTION
### Brief summary of what the package does

This package provides a simple syntax highlighting mode for kepago scripts used in the RealLive engine.

### Direct link to the package repository

https://git.sr.ht/~shiorid/seen.el

### Your association with the package

I am the maintainer.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
