### PR TITLE
+ sanma(triple) zhengma dict

### DIFF
--- a/recipes/pyim-smzmdict
+++ b/recipes/pyim-smzmdict
@@ -1,0 +1,3 @@
+(pyim-smzmdict :repo "p1uxtar/pyim-smzmdict"
+               :fetcher github
+               :files (:defaults "*.pyim"))


### PR DESCRIPTION
### Brief summary of what the package does

This is the dict/thesaurus file of the Chinese character input method Sanma (triple) Zhengma. This scheme is an improved version of [Zhengma](https://zh.wikibooks.org/wiki/%E9%83%91%E7%A0%81%E8%BE%93%E5%85%A5%E6%B3%95), which has been developed by Zhizhi for more than ten years.
This package is a solution of smzm (Sanma Zhengma) adapted to the [pyim](https://github.com/tumashu/pyim) input method, and its mode of action is consistent with [pyim-wbdict](https://github.com/tumashu/pyim-wbdict) and [pyim-cangjie5dict](https://github.com/p1uxtar/pyim-cangjie5dict), etc.

### Direct link to the package repository

https://github.com/p1uxtar/pyim-smzmdict

### Your association with the package

I'm the maintainer and one of the users of this project, the original author (Zhizhi) sent me the dict source and he doesn't use GitHub or other version control software.

### Relevant communications with the upstream package maintainer

The author of pyim [tumashu](https://github.com/tumashu) has agreed that this scheme can be incorporated into pyim. Once melpa is included, he will merge the PR of pyim simultaneously.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I have confirmed some of these without doing them
