### PR TITLE
Add org-notifications recipe

### DIFF
--- a/recipes/desktop-mail-user-agent
+++ b/recipes/desktop-mail-user-agent
@@ -1,0 +1,2 @@
+(desktop-mail-user-agent
+ :fetcher github :repo "lassik/emacs-desktop-mail-user-agent")

--- a/recipes/gams-mode
+++ b/recipes/gams-mode
@@ -1,5 +1,5 @@
 (gams-mode
  :repo "ShiroTakeda/gams-mode"
  :fetcher github
- :files ("gams-mode.el")
+ :files ("gams-mode.el" "gams-logo.xpm")
 )

--- a/recipes/numpydoc
+++ b/recipes/numpydoc
@@ -1,0 +1,1 @@
+(numpydoc :fetcher github :repo "douglasdavis/numpydoc.el")

--- a/recipes/org-notifications
+++ b/recipes/org-notifications
@@ -1,0 +1,4 @@
+(org-notifications
+ :fetcher github
+ :repo "doppelc/org-notifications"
+ :files (:defaults "sounds"))

--- a/recipes/parse-it
+++ b/recipes/parse-it
@@ -1,1 +1,1 @@
-(parse-it :repo "jcs-elpa/parse-it" :fetcher github)
+(parse-it :repo "jcs-elpa/parse-it" :fetcher github :files (:defaults "langs/*.el"))


### PR DESCRIPTION
### Brief summary of what the package does

This package creates system notifications for org-agenda items with timestamps.

- Notify a set couple of minutes before the timestamp
- Choose which agenda or non-agenda files to check or both
- Optional sound on notifications
- Exclude and include specific agenda tags
- Notifies for repeated items

### Direct link to the package repository

https://github.com/doppelc/org-notifications

### Your association with the package

Maintainer.

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
