### PR TITLE
Add recipe for flycheck-raku

### DIFF
--- a/recipes/flycheck-raku
+++ b/recipes/flycheck-raku
@@ -1,0 +1,1 @@
+(flycheck-raku :fetcher github :repo "Raku/flycheck-raku")


### PR DESCRIPTION
### Brief summary of what the package does

Checks Raku programming language syntax using flycheck

### Direct link to the package repository

https://github.com/Raku/flycheck-raku

### Your association with the package

A contributor

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them

### Additional Notes

Since the name of Perl 6 programming language was changed to Raku, I think `flycheck-perl6` on melpa should be deleted, because it works on `perl6-mode` which no longer exists on melpa(it was replaced with `raku-mode`).

This package is a community fork of a fork of the original [flycheck-perl6](https://github.com/hinrik/flycheck-perl6) by @hinrik.