### PR TITLE
Add recipe for zotero

### DIFF
--- a/recipes/zotero
+++ b/recipes/zotero
@@ -1,0 +1,4 @@
+(zotero
+ :fetcher gitlab
+ :repo "fvdbeek/emacs-zotero"
+ :files ("*.el" "img" (:exclude "*-test.el")))


### PR DESCRIPTION
### Brief summary of what the package does

Emacs-zotero is a GNU Emacs interface to the [Zotero Web API v3](https://www.zotero.org/support/dev/web_api/v3/start). It provides wrapper functions to access the API, functions to cache and sync emacs-zotero with the Zotero server, and a browser to interact with the cache.

### Direct link to the package repository

https://gitlab.com/fvdbeek/emacs-zotero

### Your association with the package

I am the maintainer

### Relevant communications with the upstream package maintainer

None needed

### Checklist

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
