### PR TITLE
Add stimmung theme

### DIFF
--- a/recipes/stimmung-theme
+++ b/recipes/stimmung-theme
@@ -1,0 +1,1 @@
+(stimmung-theme :fetcher github :repo "motform/stimmung")

--- a/recipes/stimmung-theme
+++ b/recipes/stimmung-theme
@@ -1,1 +1,0 @@
-(stimmung-theme :fetcher github :repo "motform/stimmung")

--- a/recipes/stimmung-themes
+++ b/recipes/stimmung-themes
@@ -1,0 +1,1 @@
+(stimmung-themes :fetcher github :repo "motform/stimmung")

--- a/recipes/stimmung-themes
+++ b/recipes/stimmung-themes
@@ -1,1 +1,1 @@
-(stimmung-themes :fetcher github :repo "motform/stimmung")
+(stimmung-themes :fetcher github :repo "motform/stimmung-themes")


### PR DESCRIPTION
### Brief summary of what the package does

_Stimmung_ is a pair of monochrome-ish Emacs themes with minimal syntax highlighting. They are inspired by [Tonsky's Alabaster theme](https://github.com/tonsky/sublime-scheme-alabaster), similarly arguing that excessive highlighting paradoxically hides syntactic distinctions. Unlike Tonksy, I find the use of bold and italic fonts rather pleasant. As such, font variations are employed those conservatively throughout the theme. The hues of the _stimmung-dark_ are selected to match the default MacOS dark mode.

### Direct link to the package repository

https://github.com/motform/stimmung

### Your association with the package

I am the creator of the package.

### Relevant communications with the upstream package maintainer

None needed.

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them
