### PR TITLE
Add ivy-spotify recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,6 @@ jobs:
         # Work around SSL-related failures, see
         # https://stackoverflow.com/questions/21477683/mercurial-https-clone-abort-error-wrong-version-number
         echo "[ui]\ntls = False" > $HOME/.hgrc
-
-        # Use cask to install development dependencies
-        curl -fsSkL https://raw.github.com/cask/cask/master/go | python
-    - name: Run cask
-      run: |
-        ~/.cask/bin/cask
     - name: Check changed recipes
       run: |
         [ "$GITHUB_EVENT_NAME" = "push" ] \

--- a/Cask
+++ b/Cask
@@ -1,3 +1,0 @@
-(source "melpa" "https://melpa.org/packages/")
-
-

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ $(RCPDIR)/.dirstamp: .FORCE
 ## Recipe rules
 $(RCPDIR)/%: .FORCE
 	@echo " • Building package $(@F) ..."
-	@- exec 2>&1; exec &> >(tee $(PKGDIR)/$(@F).log); \
+	@exec 2>&1; exec &> >(tee $(PKGDIR)/$(@F).log); \
 	  $(TIMEOUT) $(EVAL) "(package-build-archive \"$(@F)\")" \
 	  && echo " ✓ Success:" \
 	  && ls -lsh $(PKGDIR)/$(@F)-*

--- a/docker/builder/parallel_build_all
+++ b/docker/builder/parallel_build_all
@@ -15,7 +15,7 @@ function build_all {
 
     ## run the script
     cd "/mnt/store/melpa"
-    make -j8 $(grep --files-without-match ':fetcher\s*wiki' $(find recipes/ -type f -not -name python-info -and -not -name python3-info | sort)) &
+    make -k -j8 $(grep --files-without-match ':fetcher\s*wiki' $(find recipes/ -type f -not -name python-info -and -not -name python3-info | sort)) &
     wait
 
     # python-info and python3-info are too big to run while other are

--- a/recipes/company
+++ b/recipes/company
@@ -1,2 +1,1 @@
-(company :repo "company-mode/company-mode" :fetcher github)
-
+(company :repo "company-mode/company-mode" :fetcher github :files (:defaults "icons"))

--- a/recipes/consult-recoll
+++ b/recipes/consult-recoll
@@ -1,0 +1,3 @@
+(consult-recoll
+ :fetcher git
+ :url "https://codeberg.org/jao/consult-recoll.git")

--- a/recipes/geiser-mit
+++ b/recipes/geiser-mit
@@ -1,0 +1,4 @@
+(geiser-mit
+ :fetcher gitlab
+ :repo "emacs-geiser/mit"
+ :files (:defaults ("src" "src/*")))

--- a/recipes/geiser-racket
+++ b/recipes/geiser-racket
@@ -1,0 +1,4 @@
+(geiser-racket
+ :fetcher gitlab
+ :repo "emacs-geiser/racket"
+ :files (:defaults ("src" "src/*" "bin" "bin/*")))

--- a/recipes/ivy-spotify
+++ b/recipes/ivy-spotify
@@ -1,0 +1,4 @@
+(ivy-spotify
+ :fetcher git
+ :url "https://codeberg.org/jao/espotify"
+ :files ("ivy-spotify.el"))

--- a/recipes/molar-mass
+++ b/recipes/molar-mass
@@ -1,0 +1,1 @@
+(molar-mass :fetcher github :repo "sergiruiztrepat/molar-mass")

--- a/recipes/nroam
+++ b/recipes/nroam
@@ -1,0 +1,1 @@
+(nroam :fetcher github :repo "NicolasPetton/nroam")

--- a/recipes/revert-buffer-all
+++ b/recipes/revert-buffer-all
@@ -1,0 +1,3 @@
+(revert-buffer-all
+ :repo "ideasman42/emacs-revert-buffer-all"
+ :fetcher gitlab)

--- a/recipes/rii
+++ b/recipes/rii
@@ -1,0 +1,1 @@
+﻿(rii :repo "ROCKTAKEY/rii" :fetcher github)

--- a/recipes/stimmung-themes
+++ b/recipes/stimmung-themes
@@ -1,0 +1,1 @@
+(stimmung-themes :fetcher github :repo "motform/stimmung-themes")

--- a/recipes/theme-anchor
+++ b/recipes/theme-anchor
@@ -1,0 +1,4 @@
+(theme-anchor :repo "GongYiLiao/theme-anchor"
+	      :fetcher github
+	      :files (:defaults "theme-anchor"))
+

--- a/recipes/yaml
+++ b/recipes/yaml
@@ -1,0 +1,2 @@
+(yaml :repo "zkry/yaml.el"
+      :fetcher github)

--- a/run-ci.sh
+++ b/run-ci.sh
@@ -17,7 +17,7 @@ for recipe_name in $changed_recipes; do
     if [ -f "./recipes/$recipe_name" ]; then
         echo "----------------------------------------------------"
         echo "Building new/modified recipe: $recipe_name"
-        ~/.cask/bin/cask emacs --batch --eval "(progn (add-to-list 'load-path \"$PWD/package-build/\")(load-file \"package-build/package-build.el\")(package-build-archive \"$recipe_name\"))"
+        emacs --batch --eval "(progn (add-to-list 'load-path \"$PWD/package-build/\")(load-file \"package-build/package-build.el\")(package-build-archive \"$recipe_name\"))"
     fi
 done
 


### PR DESCRIPTION
### Brief summary of what the package does

Using ivy completion to perform Spotify web searches.

### Direct link to the package repository

https://codeberg.org/jao/espotify

### Your association with the package

Author and maintainer

### Relevant communications with the upstream package maintainer

**None needed**

### Checklist

Please confirm with `x`:

- [x] The package is released under a [GPL-Compatible Free Software License](https://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses).
- [x] I've read [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] My elisp byte-compiles cleanly
- [x] `M-x checkdoc` is happy with my docstrings
- [x] I've built and installed the package using the instructions in [CONTRIBUTING.org](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org)
- [ ] I have confirmed some of these without doing them