### PR TITLE
Update CI surrounding recent Cask issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
     - name: Install dependencies
       run: |
-        sudo apt-get install emacs25
+        sudo apt-get install emacs=1:26.3+1-1ubuntu2
         sudo apt-get install git jq mercurial texinfo
 
         # Work around SSL-related failures, see

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
         echo "[ui]\ntls = False" > $HOME/.hgrc
 
         # Use cask to install development dependencies
-        curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+        curl https://codeload.github.com/cask/cask/tar.gz/refs/tags/v0.8.6 | tar -xzv
+        mv cask-0.8.6 ~/.cask
     - name: Run cask
       run: |
         ~/.cask/bin/cask

--- a/recipes/geiser-mit
+++ b/recipes/geiser-mit
@@ -1,0 +1,4 @@
+(geiser-mit
+ :fetcher gitlab
+ :repo "emacs-geiser/mit"
+ :files (:defaults ("src" "src/*")))

--- a/recipes/revert-buffer-all
+++ b/recipes/revert-buffer-all
@@ -1,0 +1,3 @@
+(revert-buffer-all
+ :repo "ideasman42/emacs-revert-buffer-all"
+ :fetcher gitlab)


### PR DESCRIPTION
Per #7482 Cask has updated recently in two ways: it has a large deprecation notice when running with Python 2, and it's targeting a new installation method in the near future.  @lassik had a stab at this in #7484 but I think this could also be a good opportunity to update the version of Ubuntu we're building with.  What changes?

- We use the ubuntu-20.04 agent.  This has Python 3.8 on it which resolves the Cask deprecation notice
- We must apt-get install a different version of Emacs.  Unfortunately this involves an upgrade to Emacs 26
- We install a pinned version of Cask (0.8.6) by downloading the tagged archive directly from GitHub

@lassik I hope this doesn't feel like it's stepping on your toes, since you'd already opened a similar PR in this direction.